### PR TITLE
add cups-control, mount-observe, avahi-observe plugs for access to network printers

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,6 +53,9 @@ apps:
       - gsettings
       - unity7
       - network
+      - cups-control
+      - mount-observe
+      - avahi-observe
     environment:
       LC_ALL: "C.UTF-8"
       PERL5LIB: "$SNAP/usr/share/perl5/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl/5.22.1/:$SNAP/usr/share/perl/5.22.1/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl5/5.22/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl/5.22/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl-base/"


### PR DESCRIPTION
This pull-request adds cups-control, mount-observe, avahi-observe plugs to allow access to network printers.
By default these plugs are not connected and a user needs to connect them explicitly (or switch on in the permissions in Ubuntu Software).